### PR TITLE
fixed allowed instance types

### DIFF
--- a/control-plane-cf.template
+++ b/control-plane-cf.template
@@ -18,20 +18,22 @@ Parameters:
     AllowedValues:
       - t2.medium
       - t2.large
-      - m3.medium
-      - m3.large
-      - m3.xlarge
-      - m3.2xlarge
+      - t2.xlarge
+      - t2.2xlarge
+      - m5.large
+      - m5.xlarge
+      - m5.2xlarge
+      - m5.4xlarge      
       - m4.large
       - m4.xlarge
       - m4.2xlarge
       - m4.4xlarge
       - m4.10xlarge
-      - c3.large
-      - c3.xlarge
-      - c3.2xlarge
-      - c3.4xlarge
-      - c3.8xlarge
+      - c5.large
+      - c5.xlarge
+      - c5.2xlarge
+      - c5.4xlarge
+      - c5.9xlarge
       - c4.large
       - c4.xlarge
       - c4.2xlarge


### PR DESCRIPTION
m3 and c3 types are no longer available on EC2, but they have m5 and c5 instead