### PR TITLE
Add optional environment variable for GKE project id

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,7 @@ export AZURE_TENANT_ID=
 export AZURE_SUBSCRIPTION_ID=
 
 export GKE_MACHINE_TYPE=n1-standard-4
+export GKE_PROJECT_ID=
 export GKE_CLIENT_ID=
 export GKE_CLIENT_SECRET=
 export GKE_REFRESH_TOKEN=


### PR DESCRIPTION
If the `GKE_PROJECT_ID` environment variable is empty or not set, the project id came from the active configuration.