### PR TITLE
Nitpick: announce waits *before* the wait starts

### DIFF
--- a/scripts/bootstrap_arm.sh
+++ b/scripts/bootstrap_arm.sh
@@ -119,9 +119,8 @@ chown $(id -u):$(id -g) /root/.kube/config
 export KUBECONFIG=/root/.kube/config
 
 until kubectl get po --all-namespaces
-do
-  sleep 5
-  echo "Waiting...."
+do echo "($0:$LINENO) Waiting..."
+   sleep 5
 done
 
 kubectl taint nodes $(hostname -s) node-role.kubernetes.io/master:NoSchedule-


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| License         | Apache 2.0

### What's in this PR?

Currently the code silently waits for several seconds, and only then announces that it is waiting. Then it immediately stops waiting and retries the command. The fix is simply to do the announcement first. 

I also added the file and line number to the announcement string, so that if the loop seems to be stuck, the user at least knows where to look for clues. Feel free to just remove that part if you don't like it.